### PR TITLE
Fix incorrect nindent value for servicemonitor (jmx-exporter)

### DIFF
--- a/prometheus-jmx-exporter/templates/servicemonitor.yaml
+++ b/prometheus-jmx-exporter/templates/servicemonitor.yaml
@@ -25,11 +25,11 @@ spec:
       scheme: {{ .Values.serviceMonitor.scheme | default "http" }}
       {{- if .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
       {{- if .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings:
-      {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 4 }}
+      {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
       path: {{ .Values.serviceMonitor.path | default "/metrics" }}
   namespaceSelector:


### PR DESCRIPTION
Hello,

The value `nindent` 4 in prometheus-jmx-exporter [servicemonitor.yaml](https://github.com/kubegems/appstore-charts/blob/891f86f17fd627dbfab226580a45efedc0e500d8/prometheus-jmx-exporter/templates/servicemonitor.yaml) `.spec.endpoints.relabelings` and `.spec.endpoints.metricRelabelings` is incorrect. It should be set to 6.

This PR fixes it.